### PR TITLE
using simple go functions

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -102,6 +102,11 @@ func (c *Context) Set(id parser.Identifier, v parser.Value) parser.Value {
 	return v
 }
 
+// SetFn an iten in parser function map
+func (c *Context) SetFn(id parser.Identifier, v interface{}) {
+	c.env[id] = parser.NewAny(v, nil)
+}
+
 // dispatch takes the provided value, evaluates it based on the current content
 // of the context and returns the result. All errors are sent through panics.
 func (c *Context) dispatch(input parser.Value) (parser.Value, error) {
@@ -235,7 +240,7 @@ func NewContext(parent *Context) *Context {
 		"*":        OpMul,
 		"*int64":   OpMulInt64,
 		"*float64": OpMulFloat64,
-		"**":       OpPow,		
+		"**":       OpPow,
 		"==":       OpEqual,
 		"!=":       OpNotEqual,
 		"<":        OpLess,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2,8 +2,12 @@ package runtime
 
 import (
 	"fmt"
+	"math"
 	"reflect"
+	"strings"
 	"testing"
+
+	"math/rand"
 
 	"github.com/rumlang/rum/parser"
 )
@@ -201,4 +205,27 @@ func TestUnknownVariable(t *testing.T) {
 	if err == nil {
 		t.Fatalf("%q should have generated an error.", s)
 	}
+}
+
+func TestGoFunction(t *testing.T) {
+	c := NewContext(nil)
+
+	c.SetFn("rand", rand.Int63)
+	_, err := c.TryEval(mustParse("(rand)"))
+	if err != nil {
+		t.Fatalf("(rand) should have generated an error.", err)
+	}
+
+	c.SetFn("sin", math.Sin)
+	v, err := c.TryEval(mustParse("(sin 1.0)"))
+	if err != nil {
+		t.Fatalf("(rand) should have generated an error.", err)
+	}
+
+	c.SetFn("split", strings.Split)
+	v, err = c.TryEval(mustParse("(split \"1,2,3,4,5\" \",\" )"))
+	if err != nil {
+		t.Fatalf("(rand) should have generated an error.", err)
+	}
+	fmt.Println(v)
 }


### PR DESCRIPTION
That code is a simple way to use golang functions in rum scripts. Only the primitive types in rum parser.Values can be used as parameters or returns. 