### PR TITLE
Implements import feature

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -254,6 +254,7 @@ func NewContext(parent *Context) *Context {
 			"eval":     Internal(Eval),
 			"for":      Internal(For),
 			".":        Internal(Invoke),
+			"import":   Internal(Import),
 			"panic":    Panic,
 			"len":      Length,
 			"print":    Print,
@@ -297,6 +298,24 @@ func Package(name string, values ...interface{}) interface{} {
 		return nil
 	}
 	return values[len(values)-1]
+}
+
+// Import implements the import package feature.
+func Import(ctx *Context, args ...parser.Value) parser.Value {
+	if len(args) == 0 {
+		panic("Invalid arguments")
+	}
+
+	packageName, ok := args[0].Value().(string)
+	if !ok {
+		panic("invalid package name")
+	}
+	LoadStdLib(packageName, ctx)
+	v, err := ctx.TryEval(args[0])
+	if err != nil {
+		panic(err.Error())
+	}
+	return v
 }
 
 // Let implements the let reserved word.

--- a/runtime/stdlib.go
+++ b/runtime/stdlib.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StdLib interface {
+	LoadLib(ctx *Context)
+}
+
+// StringLib struct
+type StringLib struct{}
+
+// LoadLib function to StringLib struct
+func (l *StringLib) LoadLib(ctx *Context) {
+	ctx.SetFn("strings.Compare", strings.Compare, CheckArity(2))
+	ctx.SetFn("strings.Contains", strings.Contains, CheckArity(2))
+	ctx.SetFn("strings.Count", strings.Count, CheckArity(2))
+	ctx.SetFn("strings.Join", strings.Join, CheckArity(2))
+	ctx.SetFn("strings.Split", strings.Split, CheckArity(2))
+	ctx.SetFn("strings.Title", strings.Title, CheckArity(1))
+	ctx.SetFn("strings.ToLower", strings.ToLower, CheckArity(1))
+	ctx.SetFn("strings.ToUpper", strings.ToUpper, CheckArity(1))
+	ctx.SetFn("strings.Trim", strings.Trim, CheckArity(2))
+	ctx.SetFn("strings.NewReader", strings.NewReader, CheckArity(1))
+}
+
+func LoadStdLib(name string, ctx *Context) {
+	var stdLib StdLib
+	switch name {
+	case "strings":
+		stdLib = &StringLib{}
+		stdLib.LoadLib(ctx)
+		return
+	default:
+		panic(fmt.Sprintf("package %s not found", name))
+	}
+}

--- a/runtime/stdlib_test.go
+++ b/runtime/stdlib_test.go
@@ -1,0 +1,59 @@
+package runtime
+
+import (
+	"fmt"
+	"github.com/rumlang/rum/parser"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func checkSExprs(t *testing.T, firstParser string, valid map[string]interface{}) {
+	c := NewContext(nil)
+	p, err := parser.Parse(parser.NewSource(firstParser))
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unable to parse %q, %s", firstParser, err.Error()))
+	}
+	_, err = c.TryEval(p)
+	if err != nil {
+		t.Fatalf(firstParser, err.Error())
+	}
+
+	for input, expected := range valid {
+		p, err := parser.Parse(parser.NewSource(input))
+		if err != nil {
+			panic(fmt.Sprintf("Unable to parse %q: %v", input, err))
+		}
+
+		val, err := c.TryEval(p)
+		if err != nil {
+			t.Fatalf(input, err.Error())
+		}
+
+		r := val.Value()
+		if !reflect.DeepEqual(r, expected) {
+			t.Errorf("Input %q -- expected <%T>%#+v, got: <%T>%#+v", input, expected, expected, r, r)
+		}
+	}
+}
+
+func TestStrings(t *testing.T) {
+	valid := map[string]interface{}{
+		"(strings.Compare \"123\" \"123\")":                    int(0),
+		"(strings.Compare \"0123\" \"123\")":                   int(-1),
+		"(strings.Compare \"123\" \"0123\")":                   int(1),
+		"(strings.Contains \"seafood\" \"foo\")":               true,
+		"(strings.Contains \"seafood\" \"bar\")":               false,
+		"(strings.Contains \"seafood\" \"\")":                  true,
+		"(strings.Contains \"\" \"\")":                         true,
+		"(strings.Count \"cheese\" \"e\")":                     int(3),
+		"(strings.Count \"five\" \"\")":                        int(5),
+		"(strings.Split \"a,b,c\" \",\")":                      []string{"a", "b", "c"},
+		"(strings.Title \"her royal highness\")":               "Her Royal Highness",
+		"(strings.ToLower \"Gophers\")":                        "gophers",
+		"(strings.ToUpper \"Gophers\")":                        "GOPHERS",
+		"(strings.Trim \" !!! Achtung! Achtung! !!!\" \" !\")": "Achtung! Achtung",
+		"(strings.NewReader \"0123456789\")":                   strings.NewReader("0123456789"),
+	}
+	checkSExprs(t, `(import "strings")`, valid)
+}


### PR DESCRIPTION
#100 #98 refer

This implementation is a first draf to import feature. By now, just `stdlib's` can be imported to runtime of `Rum`.

The `stdlib` it's a go interface with a func called `LoadLib`, with basically set real Go functions to context of runtime.

If package name is not found, should be raise a panic by interpreter Rum.

- Alias is not accepted yet.
- import specific function is not accepted yet